### PR TITLE
fix(core): inconsistent kebab casing comparison

### DIFF
--- a/packages/core/src/writers/target-tags.ts
+++ b/packages/core/src/writers/target-tags.ts
@@ -95,7 +95,7 @@ export const generateTargetForTags = (
             isAngularClient ? mutator.hasThirdArg : mutator.hasSecondArg,
           );
           const operationNames = Object.values(builder.operations)
-            .filter(({ tags }) => tags.includes(tag))
+            .filter(({ tags }) => tags.map(kebab).includes(tag))
             .map(({ operationName }) => operationName);
 
           const typescriptVersion =


### PR DESCRIPTION
Fixing an issue where operationNames were being filtered out and not provided to builder.footer.

generateTargetTags returns kebab-cased tags which are then compared to operation tags which have not been run through the kebab routine.

map all operation tags with kebab prior to checking that the tags include a tag.